### PR TITLE
Add daily challenge result fetching and ally details UI

### DIFF
--- a/WatchMeGo/Controller/Challenge/ChallengeViewController.swift
+++ b/WatchMeGo/Controller/Challenge/ChallengeViewController.swift
@@ -118,7 +118,7 @@ class ChallengeViewController: UIViewController {
     }
     
     private func openAllyDetails(name: String, days: Int) {
-        let vc = PodiumAllyDetailsViewController()
+        let vc = PodiumAllyDetailsViewController(allyNickname: name, currentStreak: days)
         vc.title = name
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/WatchMeGo/Controller/Challenge/PodiumAllyDetailsViewController.swift
+++ b/WatchMeGo/Controller/Challenge/PodiumAllyDetailsViewController.swift
@@ -8,11 +8,69 @@
 import UIKit
 
 class PodiumAllyDetailsViewController: UIViewController {
-    
+
+    private let allyNickname: String
+    private let currentStreak: Int
+    private var dailyResults: [DailyChallengeResult] = []
+
     private let detailsView = PodiumAllyDetailsView()
+
+    init(allyNickname: String, currentStreak: Int) {
+        self.allyNickname = allyNickname
+        self.currentStreak = currentStreak
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         view = detailsView
+        title = allyNickname
+        fetchDailyResults()
+    }
+
+    private func fetchDailyResults() {
+        guard let userNickname = UserDefaults.standard.string(forKey: "loggedInNickname") else { return }
+
+        FirestoreService.shared.fetchDailyChallengeResults(for: userNickname, allyNickname: allyNickname) { [weak self] results in
+            DispatchQueue.main.async {
+                self?.dailyResults = results
+                self?.updateUI()
+            }
+        }
+    }
+
+    private func updateUI() {
+        detailsView.currentStreakLabel.text = "Current streak: \(currentStreak) days"
+        detailsView.longestStreakLabel.text = "Longest streak: \(calculateLongestStreak()) days"
+
+        if let latest = dailyResults.first {
+            let stepsGoal = UserDefaults.standard.integer(forKey: "\(allyNickname)_stepsGoal")
+            let standGoal = UserDefaults.standard.integer(forKey: "\(allyNickname)_standGoal")
+            let caloriesGoal = UserDefaults.standard.integer(forKey: "\(allyNickname)_caloriesGoal")
+
+            detailsView.progressCard.setSteps(current: latest.allySteps ?? 0, goal: stepsGoal == 0 ? 10000 : stepsGoal)
+            detailsView.progressCard.setStandHours(current: latest.allyStand ?? 0, goal: standGoal == 0 ? 10 : standGoal)
+            detailsView.progressCard.setCalories(current: latest.allyCalories ?? 0, goal: caloriesGoal == 0 ? 800 : caloriesGoal)
+        }
+
+        detailsView.displayDailyResults(dailyResults)
+    }
+
+    private func calculateLongestStreak() -> Int {
+        var longest = 0
+        var current = 0
+        for result in dailyResults.sorted(by: { $0.date < $1.date }) {
+            if result.bothChallengeMet {
+                current += 1
+                longest = max(longest, current)
+            } else {
+                current = 0
+            }
+        }
+        return longest
     }
 }

--- a/WatchMeGo/FirestoreService.swift
+++ b/WatchMeGo/FirestoreService.swift
@@ -95,4 +95,53 @@ class FirestoreService {
                 completion(streaks)
             }
     }
+
+    func fetchDailyChallengeResults(
+        for userNickname: String,
+        allyNickname: String,
+        completion: @escaping ([DailyChallengeResult]) -> Void
+    ) {
+        db.collection("dailyChallengeResults")
+            .whereField("userNickname", isEqualTo: userNickname)
+            .whereField("allyNickname", isEqualTo: allyNickname)
+            .order(by: "date", descending: true)
+            .getDocuments { snapshot, error in
+                guard let documents = snapshot?.documents else {
+                    completion([])
+                    return
+                }
+
+                let results: [DailyChallengeResult] = documents.compactMap { doc in
+                    let data = doc.data()
+                    guard let date = data["date"] as? String,
+                          let steps = data["steps"] as? Int,
+                          let stand = data["stand"] as? Int,
+                          let calories = data["calories"] as? Int,
+                          let userChallengeMet = data["userChallengeMet"] as? Bool,
+                          let bothChallengeMet = data["bothChallengeMet"] as? Bool else {
+                        return nil
+                    }
+
+                    let allySteps = data["allySteps"] as? Int
+                    let allyStand = data["allyStand"] as? Int
+                    let allyCalories = data["allyCalories"] as? Int
+                    let allyChallengeMet = data["allyChallengeMet"] as? Bool
+
+                    return DailyChallengeResult(
+                        date: date,
+                        steps: steps,
+                        stand: stand,
+                        calories: calories,
+                        userChallengeMet: userChallengeMet,
+                        allySteps: allySteps,
+                        allyStand: allyStand,
+                        allyCalories: allyCalories,
+                        allyChallengeMet: allyChallengeMet,
+                        bothChallengeMet: bothChallengeMet
+                    )
+                }
+
+                completion(results)
+            }
+    }
 }

--- a/WatchMeGo/Model/DailyChallengeResult.swift
+++ b/WatchMeGo/Model/DailyChallengeResult.swift
@@ -1,0 +1,21 @@
+//
+//  DailyChallengeResult.swift
+//  WatchMeGo
+//
+//  Created by Liza on 21/06/2025.
+//
+
+import Foundation
+
+struct DailyChallengeResult {
+    let date: String
+    let steps: Int
+    let stand: Int
+    let calories: Int
+    let userChallengeMet: Bool
+    let allySteps: Int?
+    let allyStand: Int?
+    let allyCalories: Int?
+    let allyChallengeMet: Bool?
+    let bothChallengeMet: Bool
+}

--- a/WatchMeGo/View/Challenge/PodiumAllyDetailsView.swift
+++ b/WatchMeGo/View/Challenge/PodiumAllyDetailsView.swift
@@ -8,32 +8,72 @@
 import UIKit
 
 class PodiumAllyDetailsView: UIView {
-    
-    let statusLabel = UILabel()
-    
+
+    let progressCard = ProgressCardView()
+    let currentStreakLabel = UILabel()
+    let longestStreakLabel = UILabel()
+    let resultsStack = UIStackView()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     private func setupUI() {
         backgroundColor = AppStyle.Colors.background
-        
-        addSubview(statusLabel)
-        
-        statusLabel.text = "Work in progress 🚧"
-        statusLabel.font = UIFont.systemFont(ofSize: 24, weight: .medium)
-        statusLabel.textAlignment = .center
-        statusLabel.textColor = AppStyle.Colors.textPrimary
-        statusLabel.translatesAutoresizingMaskIntoConstraints = false
-        
+
+        addSubview(progressCard)
+        addSubview(currentStreakLabel)
+        addSubview(longestStreakLabel)
+        addSubview(resultsStack)
+
+        progressCard.translatesAutoresizingMaskIntoConstraints = false
+
+        currentStreakLabel.font = .systemFont(ofSize: 18, weight: .medium)
+        currentStreakLabel.textColor = AppStyle.Colors.textPrimary
+        currentStreakLabel.textAlignment = .center
+        currentStreakLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        longestStreakLabel.font = .systemFont(ofSize: 15)
+        longestStreakLabel.textColor = AppStyle.Colors.textSecondary
+        longestStreakLabel.textAlignment = .center
+        longestStreakLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        resultsStack.axis = .vertical
+        resultsStack.spacing = 8
+        resultsStack.translatesAutoresizingMaskIntoConstraints = false
+
         NSLayoutConstraint.activate([
-            statusLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-            statusLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+            progressCard.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 20),
+            progressCard.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            progressCard.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            progressCard.heightAnchor.constraint(equalToConstant: 250),
+
+            currentStreakLabel.topAnchor.constraint(equalTo: progressCard.bottomAnchor, constant: 20),
+            currentStreakLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+
+            longestStreakLabel.topAnchor.constraint(equalTo: currentStreakLabel.bottomAnchor, constant: 8),
+            longestStreakLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+
+            resultsStack.topAnchor.constraint(equalTo: longestStreakLabel.bottomAnchor, constant: 20),
+            resultsStack.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            resultsStack.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor)
         ])
+    }
+
+    func displayDailyResults(_ results: [DailyChallengeResult]) {
+        resultsStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        for result in results {
+            let label = UILabel()
+            label.font = .systemFont(ofSize: 14)
+            label.textColor = AppStyle.Colors.textPrimary
+            label.text = "\(result.date): \(result.bothChallengeMet ? "✅" : "❌")"
+            resultsStack.addArrangedSubview(label)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `DailyChallengeResult` model
- add `fetchDailyChallengeResults` in `FirestoreService`
- enhance `PodiumAllyDetailsView` UI with progress card and streak labels
- load ally data in `PodiumAllyDetailsViewController`
- pass ally nickname and streak to details controller

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_686415ef5f30832380d6af8aa9c76df3