### PR TITLE
Improve UI styling and seed sample data

### DIFF
--- a/WatchMeGo/AppDelegate.swift
+++ b/WatchMeGo/AppDelegate.swift
@@ -16,6 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         FirebaseApp.configure()
+        SampleDataSeeder.seedIfNeeded()
         return true
     }
 

--- a/WatchMeGo/Service/AppStyle.swift
+++ b/WatchMeGo/Service/AppStyle.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 struct AppStyle {
-    
+
     struct Colors {
         static var background: UIColor {
             UIColor(light: "#F8F8FC", dark: "#181520")
@@ -33,6 +33,16 @@ struct AppStyle {
         static var buttonText: UIColor {
             UIColor(light: "#5A69FF", dark: "#7D8BFF")
         }
+    }
+
+    struct Fonts {
+        static var largeTitle: UIFont { .systemFont(ofSize: 32, weight: .bold) }
+        static var title: UIFont { .systemFont(ofSize: 22, weight: .bold) }
+        static var subtitle: UIFont { .systemFont(ofSize: 18, weight: .semibold) }
+        static var body: UIFont { .systemFont(ofSize: 16) }
+        static var caption: UIFont { .systemFont(ofSize: 13) }
+        static var button: UIFont { .systemFont(ofSize: 18, weight: .bold) }
+        static var smallButton: UIFont { .systemFont(ofSize: 15, weight: .bold) }
     }
 }
 

--- a/WatchMeGo/Service/SampleDataSeeder.swift
+++ b/WatchMeGo/Service/SampleDataSeeder.swift
@@ -1,0 +1,66 @@
+import Foundation
+import CoreData
+
+struct SampleDataSeeder {
+    static func seedIfNeeded() {
+        let context = CoreDataManager.shared.context
+        let request = User.fetchRequest()
+        let userCount = (try? context.count(for: request)) ?? 0
+        if userCount > 0 { return }
+
+        UserService.createUser(email: "alice@example.com", nickname: "Alice", password: "pass123")
+        UserService.createUser(email: "bob@example.com", nickname: "Bob", password: "pass123")
+        UserService.createUser(email: "carol@example.com", nickname: "Carol", password: "pass123")
+
+        func addFriend(owner: String, nickname: String, status: String, isAlly: Bool = false) {
+            let friend = Friend(context: context)
+            friend.id = UUID()
+            friend.owner = owner
+            friend.nickname = nickname
+            friend.status = status
+            friend.isAlly = isAlly
+        }
+
+        addFriend(owner: "Alice", nickname: "Bob", status: "accepted", isAlly: true)
+        addFriend(owner: "Bob", nickname: "Alice", status: "accepted")
+        addFriend(owner: "Bob", nickname: "Carol", status: "accepted")
+        addFriend(owner: "Carol", nickname: "Bob", status: "accepted")
+        addFriend(owner: "Alice", nickname: "Carol", status: "pending")
+
+        try? context.save()
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let dates = [Date().addingTimeInterval(-172800), Date().addingTimeInterval(-86400)]
+
+        for date in dates {
+            let dateStr = formatter.string(from: date)
+            FirestoreService.shared.saveDailyChallengeResult(
+                date: dateStr,
+                userNickname: "Alice",
+                steps: 10000,
+                stand: 12,
+                calories: 600,
+                userChallengeMet: true,
+                allyNickname: "Bob",
+                allySteps: 9500,
+                allyStand: 11,
+                allyCalories: 580,
+                allyChallengeMet: true
+            )
+            FirestoreService.shared.saveDailyChallengeResult(
+                date: dateStr,
+                userNickname: "Bob",
+                steps: 9500,
+                stand: 11,
+                calories: 580,
+                userChallengeMet: true,
+                allyNickname: "Alice",
+                allySteps: 10000,
+                allyStand: 12,
+                allyCalories: 600,
+                allyChallengeMet: true
+            )
+        }
+    }
+}

--- a/WatchMeGo/View/Auth/LoginView.swift
+++ b/WatchMeGo/View/Auth/LoginView.swift
@@ -43,7 +43,7 @@ class LoginView: UIView {
         stackView.addArrangedSubview(registerButton)
 
         titleLabel.text = "Welcome Back"
-        titleLabel.font = UIFont.boldSystemFont(ofSize: 32)
+        titleLabel.font = AppStyle.Fonts.largeTitle
         titleLabel.textColor = AppStyle.Colors.textPrimary
         titleLabel.textAlignment = .center
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -61,12 +61,12 @@ class LoginView: UIView {
         logInButton.setTitleColor(.white, for: .normal)
         logInButton.backgroundColor = AppStyle.Colors.buttonText
         logInButton.layer.cornerRadius = 16
-        logInButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 18)
+        logInButton.titleLabel?.font = AppStyle.Fonts.button
 
         registerButton.translatesAutoresizingMaskIntoConstraints = false
         registerButton.setTitle("Don't have an account? Sign up!", for: .normal)
         registerButton.setTitleColor(AppStyle.Colors.buttonText, for: .normal)
-        registerButton.titleLabel?.font = UIFont.systemFont(ofSize: 14)
+        registerButton.titleLabel?.font = AppStyle.Fonts.caption
         
         NSLayoutConstraint.activate([
             titleLabel.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 80),

--- a/WatchMeGo/View/Auth/RegisterView.swift
+++ b/WatchMeGo/View/Auth/RegisterView.swift
@@ -42,7 +42,7 @@ class RegisterView: UIView {
         stackView.addArrangedSubview(createAccountButton)
 
         titleLabel.text = "Create Account"
-        titleLabel.font = UIFont.boldSystemFont(ofSize: 32)
+        titleLabel.font = AppStyle.Fonts.largeTitle
         titleLabel.textColor = AppStyle.Colors.textPrimary
         titleLabel.textAlignment = .center
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -66,7 +66,7 @@ class RegisterView: UIView {
         createAccountButton.setTitleColor(.white, for: .normal)
         createAccountButton.backgroundColor = AppStyle.Colors.buttonText
         createAccountButton.layer.cornerRadius = 16
-        createAccountButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 18)
+        createAccountButton.titleLabel?.font = AppStyle.Fonts.button
         
         NSLayoutConstraint.activate([
             titleLabel.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 80),

--- a/WatchMeGo/View/Challenge/ChallengeView.swift
+++ b/WatchMeGo/View/Challenge/ChallengeView.swift
@@ -56,7 +56,7 @@ class ChallengeView: UIView {
         
         titleLabel.text = "Set your challenge!"
         titleLabel.textAlignment = .center
-        titleLabel.font = UIFont.systemFont(ofSize: 24, weight: .medium)
+        titleLabel.font = AppStyle.Fonts.title
         titleLabel.textColor = AppStyle.Colors.textPrimary
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         

--- a/WatchMeGo/View/Challenge/PodiumAllyDetailsView.swift
+++ b/WatchMeGo/View/Challenge/PodiumAllyDetailsView.swift
@@ -33,12 +33,12 @@ class PodiumAllyDetailsView: UIView {
 
         progressCard.translatesAutoresizingMaskIntoConstraints = false
 
-        currentStreakLabel.font = .systemFont(ofSize: 18, weight: .medium)
+        currentStreakLabel.font = AppStyle.Fonts.subtitle
         currentStreakLabel.textColor = AppStyle.Colors.textPrimary
         currentStreakLabel.textAlignment = .center
         currentStreakLabel.translatesAutoresizingMaskIntoConstraints = false
 
-        longestStreakLabel.font = .systemFont(ofSize: 15)
+        longestStreakLabel.font = AppStyle.Fonts.caption
         longestStreakLabel.textColor = AppStyle.Colors.textSecondary
         longestStreakLabel.textAlignment = .center
         longestStreakLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -70,7 +70,7 @@ class PodiumAllyDetailsView: UIView {
 
         for result in results {
             let label = UILabel()
-            label.font = .systemFont(ofSize: 14)
+            label.font = AppStyle.Fonts.caption
             label.textColor = AppStyle.Colors.textPrimary
             label.text = "\(result.date): \(result.bothChallengeMet ? "✅" : "❌")"
             resultsStack.addArrangedSubview(label)

--- a/WatchMeGo/View/Challenge/PodiumView.swift
+++ b/WatchMeGo/View/Challenge/PodiumView.swift
@@ -36,18 +36,18 @@ class PodiumView: UIView {
         layer.borderColor = borderColors[place].cgColor
         
         iconLabel.text = icons[place]
-        iconLabel.font = .systemFont(ofSize: 28)
+        iconLabel.font = AppStyle.Fonts.title
         iconLabel.textAlignment = .center
         iconLabel.translatesAutoresizingMaskIntoConstraints = false
         
         nameLabel.text = name
-        nameLabel.font = .systemFont(ofSize: 18, weight: .semibold)
+        nameLabel.font = AppStyle.Fonts.subtitle
         nameLabel.textAlignment = .left
         nameLabel.textColor = AppStyle.Colors.textPrimary
         nameLabel.translatesAutoresizingMaskIntoConstraints = false
         
         daysLabel.text = "\(days) days 🔥"
-        daysLabel.font = .systemFont(ofSize: 14)
+        daysLabel.font = AppStyle.Fonts.caption
         daysLabel.textColor = AppStyle.Colors.textSecondary
         daysLabel.textAlignment = .right
         daysLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/WatchMeGo/View/Components/PrimaryButtonView.swift
+++ b/WatchMeGo/View/Components/PrimaryButtonView.swift
@@ -29,7 +29,7 @@ class PrimaryButtonView: UIView {
         button.backgroundColor = AppStyle.Colors.buttonText
         button.layer.cornerRadius = 12
         button.clipsToBounds = true
-        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 15)
+        button.titleLabel?.font = AppStyle.Fonts.smallButton
         button.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([

--- a/WatchMeGo/View/Components/PrimaryInputView.swift
+++ b/WatchMeGo/View/Components/PrimaryInputView.swift
@@ -30,7 +30,7 @@ class PrimaryInputView: UIView {
         textField.placeholder = placeholder
         textField.backgroundColor = .clear
         textField.keyboardType = .numberPad
-        textField.font = UIFont.systemFont(ofSize: 14)
+        textField.font = AppStyle.Fonts.body
         textField.textColor = AppStyle.Colors.textPrimary
         textField.borderStyle = .none
         textField.clearButtonMode = .whileEditing

--- a/WatchMeGo/View/Friends/FriendsView.swift
+++ b/WatchMeGo/View/Friends/FriendsView.swift
@@ -51,6 +51,7 @@ class FriendsView: UIView {
         contentStack.addArrangedSubview(acceptedFriendsLabel)
         contentStack.addArrangedSubview(acceptedFriendsContainer)
         contentStack.addArrangedSubview(logoutButton)
+        contentStack.setCustomSpacing(40, after: acceptedFriendsContainer)
 
         inputStack.axis = .horizontal
         inputStack.spacing = 12
@@ -63,7 +64,7 @@ class FriendsView: UIView {
 
         titleLabel.text = "Friends Hub"
         titleLabel.textAlignment = .center
-        titleLabel.font = UIFont.boldSystemFont(ofSize: 32)
+        titleLabel.font = AppStyle.Fonts.largeTitle
         titleLabel.textColor = AppStyle.Colors.textPrimary
         titleLabel.setContentHuggingPriority(.required, for: .vertical)
 
@@ -72,7 +73,7 @@ class FriendsView: UIView {
         inviteButton.translatesAutoresizingMaskIntoConstraints = false
 
         pendingInvitesLabel.text = "Invites"
-        pendingInvitesLabel.font = UIFont.systemFont(ofSize: 20, weight: .semibold)
+        pendingInvitesLabel.font = AppStyle.Fonts.subtitle
         pendingInvitesLabel.textColor = AppStyle.Colors.textPrimary
 
         pendingInvitesContainer.layer.cornerRadius = 12
@@ -90,7 +91,7 @@ class FriendsView: UIView {
         pendingInvitesTable.translatesAutoresizingMaskIntoConstraints = false
 
         acceptedFriendsLabel.text = "Friends"
-        acceptedFriendsLabel.font = UIFont.systemFont(ofSize: 20, weight: .semibold)
+        acceptedFriendsLabel.font = AppStyle.Fonts.subtitle
         acceptedFriendsLabel.textColor = AppStyle.Colors.textPrimary
 
         acceptedFriendsContainer.layer.cornerRadius = 12
@@ -107,7 +108,7 @@ class FriendsView: UIView {
         acceptedFriendsTable.translatesAutoresizingMaskIntoConstraints = false
 
         logoutButton.setTitle("Logout", for: .normal)
-        logoutButton.titleLabel?.font = UIFont.systemFont(ofSize: 18)
+        logoutButton.titleLabel?.font = AppStyle.Fonts.button
         logoutButton.setTitleColor(AppStyle.Colors.textPrimary, for: .normal)
         logoutButton.translatesAutoresizingMaskIntoConstraints = false
 
@@ -115,6 +116,7 @@ class FriendsView: UIView {
             contentStack.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 20),
             contentStack.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
             contentStack.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -20),
 
             friendsNicknameTextField.heightAnchor.constraint(equalToConstant: 44),
             inviteButton.widthAnchor.constraint(equalToConstant: 100),

--- a/WatchMeGo/View/Main/MainView.swift
+++ b/WatchMeGo/View/Main/MainView.swift
@@ -35,13 +35,13 @@ class MainView: UIScrollView {
         addSubview(allyProgressCard)
         
         titleLabel.text = "WatchMeGo"
-        titleLabel.font = UIFont.boldSystemFont(ofSize: 32)
+        titleLabel.font = AppStyle.Fonts.largeTitle
         titleLabel.textColor = AppStyle.Colors.textPrimary
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         
         userProgressCard.translatesAutoresizingMaskIntoConstraints = false
         
-        nicknameLabel.font = UIFont.systemFont(ofSize: 13)
+        nicknameLabel.font = AppStyle.Fonts.caption
         nicknameLabel.textColor = AppStyle.Colors.textSecondary
         nicknameLabel.translatesAutoresizingMaskIntoConstraints = false
           

--- a/WatchMeGo/View/Main/ProgressBarRowView.swift
+++ b/WatchMeGo/View/Main/ProgressBarRowView.swift
@@ -40,7 +40,7 @@ class ProgressBarRowView: UIView {
         iconView.translatesAutoresizingMaskIntoConstraints = false
         
         titleLabel.text = title
-        titleLabel.font = UIFont.systemFont(ofSize: 16, weight: .medium)
+        titleLabel.font = AppStyle.Fonts.body
         titleLabel.textColor = AppStyle.Colors.textPrimary
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         

--- a/WatchMeGo/View/Main/ProgressCardView.swift
+++ b/WatchMeGo/View/Main/ProgressCardView.swift
@@ -38,7 +38,7 @@ class ProgressCardView: UIView {
         
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.text = "Today's Progress"
-        titleLabel.font = UIFont.boldSystemFont(ofSize: 22)
+        titleLabel.font = AppStyle.Fonts.title
         titleLabel.textColor = AppStyle.Colors.textPrimary
         
         stepsRow.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
## Summary
- define `AppStyle.Fonts` for consistent typography
- apply unified fonts across all views
- adjust Friends screen layout and move logout button lower
- seed Core Data and Firestore with example users, friends and challenge data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68641d2ff7788323aea37cfa12c5ff5f