### PR TITLE
Update color palette

### DIFF
--- a/WatchMeGo/Controller/Friends/FriendCell.swift
+++ b/WatchMeGo/Controller/Friends/FriendCell.swift
@@ -67,6 +67,6 @@ class FriendCell: UITableViewCell {
 
     func configure(with nickname: String, isAlly: Bool) {
         nicknameLabel.text = nickname
-        competeButton.tintColor = isAlly ? .red : .gray
+        competeButton.tintColor = isAlly ? AppStyle.Colors.accent : .gray
     }
 }

--- a/WatchMeGo/Controller/Main/MainViewController.swift
+++ b/WatchMeGo/Controller/Main/MainViewController.swift
@@ -96,14 +96,14 @@ class MainViewController: UIViewController {
         DispatchQueue.main.async {
             self.mainView.allyProgressCard.titleLabel.text = "\(name)'s Progress"
             
-            self.mainView.allyProgressCard.stepsRow.progressView.progressTintColor = .systemIndigo
-            self.mainView.allyProgressCard.stepsRow.iconView.tintColor = .systemIndigo
-            
-            self.mainView.allyProgressCard.standRow.progressView.progressTintColor = .systemTeal
-            self.mainView.allyProgressCard.standRow.iconView.tintColor = .systemTeal
-            
-            self.mainView.allyProgressCard.caloriesRow.progressView.progressTintColor = .systemRed
-            self.mainView.allyProgressCard.caloriesRow.iconView.tintColor = .systemRed
+            self.mainView.allyProgressCard.stepsRow.progressView.progressTintColor = AppStyle.Colors.accent
+            self.mainView.allyProgressCard.stepsRow.iconView.tintColor = AppStyle.Colors.accent
+
+            self.mainView.allyProgressCard.standRow.progressView.progressTintColor = AppStyle.Colors.accent
+            self.mainView.allyProgressCard.standRow.iconView.tintColor = AppStyle.Colors.accent
+
+            self.mainView.allyProgressCard.caloriesRow.progressView.progressTintColor = AppStyle.Colors.accent
+            self.mainView.allyProgressCard.caloriesRow.iconView.tintColor = AppStyle.Colors.accent
         }
     }
     

--- a/WatchMeGo/Service/AppStyle.swift
+++ b/WatchMeGo/Service/AppStyle.swift
@@ -30,8 +30,12 @@ struct AppStyle {
             UIColor(light: "#D4D3E0", dark: "#3D394D")
         }
 
+        static var accent: UIColor {
+            UIColor(light: "#123524", dark: "#123524")
+        }
+
         static var buttonText: UIColor {
-            UIColor(light: "#5A69FF", dark: "#7D8BFF")
+            accent
         }
     }
 

--- a/WatchMeGo/View/Main/ProgressCardView.swift
+++ b/WatchMeGo/View/Main/ProgressCardView.swift
@@ -10,9 +10,21 @@ import UIKit
 class ProgressCardView: UIView {
     var titleLabel = UILabel()
     
-    let stepsRow = ProgressBarRowView(icon: UIImage(systemName: "figure.walk"), title: "Steps", progressColor: .systemBlue)
-    let standRow = ProgressBarRowView(icon: UIImage(systemName: "figure.stand"), title: "Stand Hours", progressColor: .systemGreen)
-    let caloriesRow = ProgressBarRowView(icon: UIImage(systemName: "flame.fill"), title: "Calories", progressColor: .systemOrange)
+    let stepsRow = ProgressBarRowView(
+        icon: UIImage(systemName: "figure.walk"),
+        title: "Steps",
+        progressColor: AppStyle.Colors.accent
+    )
+    let standRow = ProgressBarRowView(
+        icon: UIImage(systemName: "figure.stand"),
+        title: "Stand Hours",
+        progressColor: AppStyle.Colors.accent
+    )
+    let caloriesRow = ProgressBarRowView(
+        icon: UIImage(systemName: "flame.fill"),
+        title: "Calories",
+        progressColor: AppStyle.Colors.accent
+    )
     
     override init(frame: CGRect) {
         super.init(frame: frame)


### PR DESCRIPTION
## Summary
- switch accent color to phthalocyanine green `#123524`
- update progress bars and ally display to use new accent color
- highlight active friend with the same tone

## Testing
- `swiftc -parse WatchMeGo/Service/AppStyle.swift`
- `swiftc -parse WatchMeGo/View/Main/ProgressCardView.swift`
- `swiftc -parse WatchMeGo/Controller/Main/MainViewController.swift`
- `swiftc -parse WatchMeGo/Controller/Friends/FriendCell.swift`


------
https://chatgpt.com/codex/tasks/task_e_68641e8761b48323837fec7b4229f62b