### PR TITLE
Restore colorful progress bars

### DIFF
--- a/WatchMeGo/Controller/Main/MainViewController.swift
+++ b/WatchMeGo/Controller/Main/MainViewController.swift
@@ -96,14 +96,14 @@ class MainViewController: UIViewController {
         DispatchQueue.main.async {
             self.mainView.allyProgressCard.titleLabel.text = "\(name)'s Progress"
             
-            self.mainView.allyProgressCard.stepsRow.progressView.progressTintColor = AppStyle.Colors.accent
-            self.mainView.allyProgressCard.stepsRow.iconView.tintColor = AppStyle.Colors.accent
+            self.mainView.allyProgressCard.stepsRow.progressView.progressTintColor = .systemIndigo
+            self.mainView.allyProgressCard.stepsRow.iconView.tintColor = .systemIndigo
 
-            self.mainView.allyProgressCard.standRow.progressView.progressTintColor = AppStyle.Colors.accent
-            self.mainView.allyProgressCard.standRow.iconView.tintColor = AppStyle.Colors.accent
+            self.mainView.allyProgressCard.standRow.progressView.progressTintColor = .systemTeal
+            self.mainView.allyProgressCard.standRow.iconView.tintColor = .systemTeal
 
-            self.mainView.allyProgressCard.caloriesRow.progressView.progressTintColor = AppStyle.Colors.accent
-            self.mainView.allyProgressCard.caloriesRow.iconView.tintColor = AppStyle.Colors.accent
+            self.mainView.allyProgressCard.caloriesRow.progressView.progressTintColor = .systemRed
+            self.mainView.allyProgressCard.caloriesRow.iconView.tintColor = .systemRed
         }
     }
     

--- a/WatchMeGo/View/Main/ProgressCardView.swift
+++ b/WatchMeGo/View/Main/ProgressCardView.swift
@@ -13,17 +13,17 @@ class ProgressCardView: UIView {
     let stepsRow = ProgressBarRowView(
         icon: UIImage(systemName: "figure.walk"),
         title: "Steps",
-        progressColor: AppStyle.Colors.accent
+        progressColor: .systemBlue
     )
     let standRow = ProgressBarRowView(
         icon: UIImage(systemName: "figure.stand"),
         title: "Stand Hours",
-        progressColor: AppStyle.Colors.accent
+        progressColor: .systemGreen
     )
     let caloriesRow = ProgressBarRowView(
         icon: UIImage(systemName: "flame.fill"),
         title: "Calories",
-        progressColor: AppStyle.Colors.accent
+        progressColor: .systemOrange
     )
     
     override init(frame: CGRect) {


### PR DESCRIPTION
## Summary
- bring back multicolor progress bars for user progress cards
- use distinct colors for ally progress bars

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686421ce962483239f8009ef093bbc00