### PR TITLE
Improve podium placeholders and fire button

### DIFF
--- a/WatchMeGo/Controller/Challenge/ChallengeViewController.swift
+++ b/WatchMeGo/Controller/Challenge/ChallengeViewController.swift
@@ -106,15 +106,18 @@ class ChallengeViewController: UIViewController {
     }
     
     @objc private func goldTapped() {
-        openAllyDetails(name: "Lizunka", days: 9)
+        guard let name = challengeView.goldView.name, let days = challengeView.goldView.days else { return }
+        openAllyDetails(name: name, days: days)
     }
-    
+
     @objc private func silverTapped() {
-        openAllyDetails(name: "Kamilka", days: 6)
+        guard let name = challengeView.silverView.name, let days = challengeView.silverView.days else { return }
+        openAllyDetails(name: name, days: days)
     }
-    
+
     @objc private func bronzeTapped() {
-        openAllyDetails(name: "Martynka", days: 3)
+        guard let name = challengeView.bronzeView.name, let days = challengeView.bronzeView.days else { return }
+        openAllyDetails(name: name, days: days)
     }
     
     private func openAllyDetails(name: String, days: Int) {
@@ -146,17 +149,14 @@ class ChallengeViewController: UIViewController {
         FirestoreService.shared.fetchAllyStreaks(for: nickname) { [weak self] streaks in
             let sorted = streaks.sorted { $0.value > $1.value }
             DispatchQueue.main.async {
-                if sorted.indices.contains(0) {
-                    self?.challengeView.goldView.nameLabel.text = sorted[0].key
-                    self?.challengeView.goldView.daysLabel.text = "\(sorted[0].value) days 🔥"
-                }
-                if sorted.indices.contains(1) {
-                    self?.challengeView.silverView.nameLabel.text = sorted[1].key
-                    self?.challengeView.silverView.daysLabel.text = "\(sorted[1].value) days 🔥"
-                }
-                if sorted.indices.contains(2) {
-                    self?.challengeView.bronzeView.nameLabel.text = sorted[2].key
-                    self?.challengeView.bronzeView.daysLabel.text = "\(sorted[2].value) days 🔥"
+                let views = [self?.challengeView.goldView, self?.challengeView.silverView, self?.challengeView.bronzeView]
+                for (index, view) in views.enumerated() {
+                    if index < sorted.count {
+                        let result = sorted[index]
+                        view?.update(name: result.key, days: result.value)
+                    } else {
+                        view?.update(name: nil, days: nil)
+                    }
                 }
             }
         }

--- a/WatchMeGo/Controller/Friends/FriendCell.swift
+++ b/WatchMeGo/Controller/Friends/FriendCell.swift
@@ -67,6 +67,6 @@ class FriendCell: UITableViewCell {
 
     func configure(with nickname: String, isAlly: Bool) {
         nicknameLabel.text = nickname
-        competeButton.tintColor = isAlly ? AppStyle.Colors.accent : .gray
+        competeButton.tintColor = isAlly ? .systemRed : .gray
     }
 }

--- a/WatchMeGo/View/Challenge/ChallengeView.swift
+++ b/WatchMeGo/View/Challenge/ChallengeView.swift
@@ -21,9 +21,9 @@ class ChallengeView: UIView {
     let caloriesGoalButton = PrimaryButtonView(title: "Submit")
     
     let podiumContainer = UIView()
-    let goldView = PodiumView(place: 0, name: "Lizunka", days: 9)
-    let silverView = PodiumView(place: 1, name: "Kamilka", days: 6)
-    let bronzeView = PodiumView(place: 2, name: "Martynka", days: 3)
+    let goldView = PodiumView(place: 0)
+    let silverView = PodiumView(place: 1)
+    let bronzeView = PodiumView(place: 2)
 
     
     override init(frame: CGRect) {

--- a/WatchMeGo/View/Challenge/PodiumAllyDetailsView.swift
+++ b/WatchMeGo/View/Challenge/PodiumAllyDetailsView.swift
@@ -24,7 +24,7 @@ class PodiumAllyDetailsView: UIView {
     }
 
     private func setupUI() {
-        backgroundColor = AppStyle.Colors.background
+        backgroundColor = UIColor.systemPink.withAlphaComponent(0.1)
 
         addSubview(progressCard)
         addSubview(currentStreakLabel)

--- a/WatchMeGo/View/Challenge/PodiumView.swift
+++ b/WatchMeGo/View/Challenge/PodiumView.swift
@@ -8,45 +8,51 @@
 import UIKit
 
 class PodiumView: UIView {
-    
+
     let iconLabel = UILabel()
     let nameLabel = UILabel()
     let daysLabel = UILabel()
-    
-    init(place: Int, name: String, days: Int) {
+
+    private let place: Int
+    private(set) var name: String?
+    private(set) var days: Int?
+
+    init(place: Int, name: String? = nil, days: Int? = nil) {
+        self.place = place
+        self.name = name
+        self.days = days
         super.init(frame: .zero)
-        setupUI(place: place, name: name, days: days)
+        setupUI()
+        update(name: name, days: days)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func setupUI(place: Int, name: String, days: Int) {
+    private func setupUI() {
         addSubview(iconLabel)
         addSubview(nameLabel)
         addSubview(daysLabel)
-        
+
         let icons = ["🥇", "🥈", "🥉"]
         let borderColors: [UIColor] = [.systemYellow, .systemGray2, .systemOrange]
-        
+
         backgroundColor = AppStyle.Colors.backgroundSecondary
         layer.cornerRadius = 14
         layer.borderWidth = 3
         layer.borderColor = borderColors[place].cgColor
-        
+
         iconLabel.text = icons[place]
         iconLabel.font = AppStyle.Fonts.title
         iconLabel.textAlignment = .center
         iconLabel.translatesAutoresizingMaskIntoConstraints = false
-        
-        nameLabel.text = name
+
         nameLabel.font = AppStyle.Fonts.subtitle
         nameLabel.textAlignment = .left
         nameLabel.textColor = AppStyle.Colors.textPrimary
         nameLabel.translatesAutoresizingMaskIntoConstraints = false
-        
-        daysLabel.text = "\(days) days 🔥"
+
         daysLabel.font = AppStyle.Fonts.caption
         daysLabel.textColor = AppStyle.Colors.textSecondary
         daysLabel.textAlignment = .right
@@ -63,5 +69,21 @@ class PodiumView: UIView {
             daysLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
             daysLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
+    }
+
+    func update(name: String?, days: Int?) {
+        self.name = name
+        self.days = days
+
+        if let name = name, let days = days {
+            nameLabel.text = name
+            daysLabel.text = "\(days) days 🔥"
+            let borderColors: [UIColor] = [.systemYellow, .systemGray2, .systemOrange]
+            layer.borderColor = borderColors[place].cgColor
+        } else {
+            nameLabel.text = "Waiting for friend"
+            daysLabel.text = ""
+            layer.borderColor = UIColor.systemGray3.cgColor
+        }
     }
 }


### PR DESCRIPTION
## Summary
- show placeholders in podium when no friends are available
- make ally details screen background rosy
- open podium details based on loaded data
- color active fire buttons in red

## Testing
- `swift --version`
- `swiftc WatchMeGo/View/Challenge/PodiumView.swift -o /tmp/podium` *(fails: no UIKit)*

------
https://chatgpt.com/codex/tasks/task_e_6864257398ec83239e9af89e908ddc3a